### PR TITLE
Set replication factor for the arangolock and dbchangelog springboot2

### DIFF
--- a/src/main/java/com/github/arangobee/dao/ChangeEntryDao.java
+++ b/src/main/java/com/github/arangobee/dao/ChangeEntryDao.java
@@ -2,6 +2,7 @@ package com.github.arangobee.dao;
 
 import java.util.Date;
 
+import com.arangodb.model.CollectionCreateOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,10 +121,13 @@ public class ChangeEntryDao {
         }
     }
 
-    private void ensureChangeLogCollectionIndex(ArangoDatabase arangoTemplate, String collectionName) {
-        ArangoCollection collection=arangoTemplate.collection(collectionName);
+    private void ensureChangeLogCollectionIndex(ArangoDatabase arangoDatabase, String collectionName) {
+
+        ArangoCollection collection = arangoDatabase.collection(collectionName);
         if (!collection.exists()) {
-            arangoTemplate.createCollection(collectionName);
+            CollectionCreateOptions collectionCreateOptions = new CollectionCreateOptions();
+            collectionCreateOptions.replicationFactor(2);
+            arangoDatabase.createCollection(collectionName, collectionCreateOptions);
         }
         indexDao.createRequiredUniqueIndex(collection);
     }

--- a/src/main/java/com/github/arangobee/dao/LockDao.java
+++ b/src/main/java/com/github/arangobee/dao/LockDao.java
@@ -4,6 +4,8 @@ import com.arangodb.ArangoCollection;
 import com.arangodb.ArangoDBException;
 import com.arangodb.ArangoDatabase;
 import com.arangodb.entity.BaseDocument;
+import com.arangodb.model.CollectionCreateOptions;
+
 
 /**
  * @author colsson11
@@ -30,9 +32,12 @@ public class LockDao {
         //	  BaseDocument indexKeys = new BaseDocument();
         //	  indexKeys.addAttribute(KEY_PROP_NAME, INDEX_SORT_ASC);
         //    IndexOptions indexOptions = new IndexOptions().unique(true).name("arangobeelock_key_idx");
-        ArangoCollection collection=arangoDatabase.collection(lockCollectionName);
-        if (!collection.exists())
-            arangoDatabase.createCollection(lockCollectionName);
+        ArangoCollection collection = arangoDatabase.collection(lockCollectionName);
+        if (!collection.exists()) {
+            CollectionCreateOptions collectionCreateOptions = new CollectionCreateOptions();
+            collectionCreateOptions.replicationFactor(2);
+            arangoDatabase.createCollection(lockCollectionName, collectionCreateOptions);
+        }
         //	  collection.ensurePersistentIndex(ImmutableList.of(KEY_PROP_NAME), new PersistentIndexOptions().unique(true));
     }
 


### PR DESCRIPTION
The `dbchangelog` and `arangolock` collections are created in Arango databases with replication factor 1 due to that on cluster environment if an instance is crashed which contains these collections then difficult to recover back.
